### PR TITLE
Enable views and actions

### DIFF
--- a/src/main/java/wirelessmesh/WirelessMeshMain.java
+++ b/src/main/java/wirelessmesh/WirelessMeshMain.java
@@ -26,10 +26,10 @@ public class WirelessMeshMain {
                                     .findServiceByName("CustomerLocationByEmailService"),
                             "customer_locations",
                             Wirelessmeshdomain.getDescriptor(),
-                            Customerlocationview.getDescriptor());
-//                    .registerAction(
-//                            new ToggleNightlightAction(),
-//                            Devicecontrol.getDescriptor().findServiceByName("DeviceControlService"));
+                            Customerlocationview.getDescriptor())
+                   .registerAction(
+                           new ToggleNightlightAction(),
+                           Devicecontrol.getDescriptor().findServiceByName("DeviceControlService"));
     //                    .registerAction(
 //                            new PublishingAction(),
 //                            Publishing.getDescriptor().findServiceByName("PublishingService"))

--- a/src/main/java/wirelessmesh/domain/CustomerLocationView.java
+++ b/src/main/java/wirelessmesh/domain/CustomerLocationView.java
@@ -2,6 +2,7 @@ package wirelessmesh.domain;
 
 import com.akkaserverless.javasdk.view.UpdateHandler;
 import com.akkaserverless.javasdk.view.View;
+import com.google.protobuf.Any;
 import customerlocationview.Customerlocationview.*;
 import wirelessmeshdomain.Wirelessmeshdomain;
 
@@ -14,5 +15,14 @@ public class CustomerLocationView {
             .setCustomerLocationId(event.getCustomerLocationId())
             .setEmail(event.getEmail())
             .build();
+    }
+
+    @UpdateHandler
+    public CustomerLocationDto catchOthers(Any Event) {
+        // FIXME: we can't return an empty result currently, so keep upserting on the same fake details
+        return CustomerLocationDto.newBuilder()
+          .setCustomerLocationId("--ignored--")
+          .setEmail("--ignored--")
+          .build();
     }
 }

--- a/src/main/proto/customerlocationview.proto
+++ b/src/main/proto/customerlocationview.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "google/api/annotations.proto";
+import "google/protobuf/any.proto";
 import "akkaserverless/annotations.proto";
 
 package customerlocationview;
@@ -37,4 +38,17 @@ service CustomerLocationByEmailService {
           get: "/wirelessmesh/customer-locations"
         };
     }
+
+    // handle other events which are not managed above
+    rpc CatchOthers(google.protobuf.Any) returns (CustomerLocationDto) {
+      option (akkaserverless.method).eventing = {
+        in: {
+          event_log: "customer-location-entity"
+        }
+      };
+      option (akkaserverless.method).view.update = {
+        table: "customer_locations"
+        transform_updates: true
+      };
+    };
 }


### PR DESCRIPTION
Add a catch all for other events in the customer location view — this is a hack right now, as I don't think we have a good way to support this (can't return empty values to not upsert, or ignore the events altogether). Otherwise the view will fail when there are unhandled events (any events other than `CustomerLocationAdded`).

Enable the toggle nightlight action, as that should be working now (with its catch other events method).